### PR TITLE
added support for payment_method_id parameter

### DIFF
--- a/Action/CaptureAction.php
+++ b/Action/CaptureAction.php
@@ -41,10 +41,12 @@ class CaptureAction implements ActionInterface, ApiAwareInterface
         $details = ArrayObject::ensureArrayObject($request->getModel());
 
         $details['service_id'] = $this->api->getServiceId();
+        $details['payment_method_id'] = $this->api->getPaymentMethodId();
         $details['hash'] = $this->api->sing($details->toUnsafeArray());
 
         $details->validatedKeysSet(array(
             'service_id',
+            'payment_method_id',
             'order_id',
             'customer_id',
             'hash',

--- a/Api.php
+++ b/Api.php
@@ -40,6 +40,11 @@ class Api
         return $this->config['service_id'];
     }
 
+    public function getPaymentMethodId()
+    {
+        return $this->config['payment_method_id'];
+    }
+
     public function getProductId()
     {
         return $this->config['product_id'];
@@ -73,7 +78,7 @@ class Api
             'summ' => null,
             'currency' => null,
             'count' => null,
-            'payment_method_id' => null,
+            'payment_method_id' => $this->getPaymentMethodId(),
             'secret_key' => $this->getSecret(),
         );
 
@@ -105,7 +110,7 @@ class Api
             'share' => null,
             'share_rub' => null,
             'transaction_date' => null,
-            'payment_method_id' => null,
+            'payment_method_id' => $this->getPaymentMethodId(),
             'product_id' => null,
             'secret_key' => $this->getSecret(),
         );

--- a/Bridge/Symfony/FlexidengiPaymentFactory.php
+++ b/Bridge/Symfony/FlexidengiPaymentFactory.php
@@ -25,6 +25,7 @@ class FlexidengiPaymentFactory extends AbstractPaymentFactory
         $builder->children()
             ->scalarNode('service_id')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('product_id')->defaultNull()->end()
+            ->scalarNode('payment_method_id')->defaultNull()->end()
             ->scalarNode('secret')->isRequired()->cannotBeEmpty()->end()
             ->booleanNode('sandbox')->defaultTrue()->end()
             ->end();

--- a/PaymentFactory.php
+++ b/PaymentFactory.php
@@ -63,6 +63,7 @@ class PaymentFactory implements PaymentFactoryInterface
             $config['payum.default_options'] = array(
                 'service_id' => null,
                 'product_id' => null,
+                'payment_method_id' => null,
                 'secret' => null,
                 'sandbox' => true,
             );
@@ -76,6 +77,7 @@ class PaymentFactory implements PaymentFactoryInterface
                 $flexidengiConfig = array(
                     'service_id' => $config['service_id'],
                     'product_id' => $config['product_id'],
+                    'payment_method_id' => $config['payment_method_id'],
                     'secret' => $config['secret'],
                     'sandbox' => $config['sandbox'],
                 );

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ payum:
         flexidengi_gateway:
             flexidengi:
                 service_id: 123
+                payment_method_id: 45
                 secret: SECRET_KEY
                 sandbox: true
         ...


### PR DESCRIPTION
Payment service optionally required for this parameter. It needs to define a specific payment method like mobile payment, bank card, etc.
